### PR TITLE
Add minimal MVP chat demo

### DIFF
--- a/docs/launch_plan.md
+++ b/docs/launch_plan.md
@@ -1,0 +1,33 @@
+# Launch Plan
+
+This document outlines the steps to begin the launch of the dyslexic-friendly chat LLM product.
+
+## Phase 1: Prototype (Weeks 1-4)
+- **Project Setup**
+  - Finalize repository structure and coding standards.
+  - Set up continuous integration and testing pipeline.
+- **Core Features**
+  - Integrate baseline language model.
+  - Implement text-to-speech and speech-to-text pipelines.
+  - Create dyslexic-friendly UI with adjustable fonts, color contrast, and focus mode.
+- **Initial Content**
+  - Curate domain-specific materials for fine-tuning and evaluation.
+- **User Feedback Loop**
+  - Recruit small group of dyslexic users, parents, and teachers for feedback.
+  - Establish channels for collecting and prioritizing feedback.
+
+## Phase 2: Beta (Months 2-4)
+- Expand feature set based on prototype feedback.
+- Add personalization and progress tracking.
+- Build resource library for accommodations and best practices.
+- Broaden testing to larger audience.
+
+## Phase 3: Public Launch (Month 6)
+- Stabilize and optimize infrastructure for scale.
+- Partner with dyslexia organizations and educational institutions.
+- Launch marketing campaign and onboarding materials.
+
+## Ongoing Improvements
+- Collect anonymized usage data for model improvement.
+- Continually refine accessibility features and resources.
+- Explore multi-language support and advanced assistive technologies.

--- a/docs/mvp_demo.md
+++ b/docs/mvp_demo.md
@@ -1,0 +1,21 @@
+# MVP Demo
+
+This demo showcases a minimal dyslexic-friendly chat experience.  The
+script connects to OpenAI's API, chunks responses into shorter lines and
+speaks them aloud when the optional `pyttsx3` package is available.
+
+## Requirements
+- Python 3.8+
+- `openai` package
+- `pyttsx3` for text-to-speech (optional)
+- An `OPENAI_API_KEY` environment variable
+
+## Usage
+```bash
+pip install openai pyttsx3  # optional
+export OPENAI_API_KEY="YOUR_KEY"
+python examples/mvp_demo.py
+```
+
+Type your question at the prompt and the assistant will answer with
+short, clear sentences.  Type `exit` to quit.

--- a/examples/mvp_demo.py
+++ b/examples/mvp_demo.py
@@ -1,0 +1,72 @@
+import os
+
+try:
+    import openai
+except ImportError:  # pragma: no cover - minimal example
+    openai = None
+
+
+def chunk_text(text: str, width: int = 80) -> str:
+    """Split text into lines of at most ``width`` characters."""
+    return "\n".join(text[i:i + width] for i in range(0, len(text), width))
+
+
+def speak_text(text: str) -> None:
+    """Attempt to speak ``text`` using ``pyttsx3``.
+
+    If the library is not installed, falls back to printing a notice
+    alongside the plain text output.
+    """
+    try:
+        import pyttsx3
+    except Exception:  # pragma: no cover - optional dependency
+        print("[speech unavailable]" )
+        print(text)
+        return
+
+    engine = pyttsx3.init()
+    engine.say(text)
+    engine.runAndWait()
+
+
+def run_chat() -> None:
+    """Simple dyslexia-friendly chat loop using OpenAI's API.
+
+    The assistant responds with concise sentences. Responses are
+    chunked to reduce visual overload and optionally spoken aloud.
+    """
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY environment variable is required")
+
+    if openai is None:
+        raise RuntimeError("The 'openai' package is required to run the demo")
+
+    openai.api_key = api_key
+
+    print("Dyslexic-friendly Chat MVP. Type 'exit' to quit.\n")
+    while True:
+        user_text = input("You: ")
+        if user_text.strip().lower() in {"exit", "quit"}:
+            break
+
+        completion = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "You are a helpful assistant that supports dyslexic "
+                        "thinkers. Use clear, short sentences."
+                    ),
+                },
+                {"role": "user", "content": user_text},
+            ],
+        )
+        reply = completion["choices"][0]["message"]["content"].strip()
+        print("\nAssistant:\n" + chunk_text(reply) + "\n")
+        speak_text(reply)
+
+
+if __name__ == "__main__":
+    run_chat()


### PR DESCRIPTION
## Summary
- Add a Python demo script that connects to OpenAI and provides chunked, optional spoken responses for dyslexic-friendly interaction
- Document requirements and usage of the MVP demo

## Testing
- `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_68c1dac02398832f90ac273a65d1f8bd